### PR TITLE
Janw

### DIFF
--- a/Cookbook.md
+++ b/Cookbook.md
@@ -160,10 +160,10 @@ save_axioms/3
 Once you have generated the above DLP you can query the ABox using SWI-Prolog:
 
 ```
-swipl wine.pl
-   ?- 'DessertWine'(Wine),locatedIn(Wine,'USRegion'),hasBody(Wine,'Light').
-Wine = 'WhitehallLanePrimavera' ? ;
-false
+$ swipl wine.pl
+?- 'DessertWine'(Wine),locatedIn(Wine,'USRegion'),hasBody(Wine,'Light').
+Wine = 'WhitehallLanePrimavera' ;
+false.
 ```
 
 Prolog DLPs can not have disjunctions in the head of

--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@ A collection of modules for parsing and manipulating OWL2 ontologies
 in Prolog. It is developed with SWI-Prolog in mind, but the goal is to
 maximize portability with other prologs, such as Yap and XSB.
 
-This documentation is intended to be read via pldoc
+> __[Aug 9, 2019]__
+> The current implementation has been updated for SWI-Prolog 8.x. As
+> SWI-Prolog now provides tabling it can both be used for its RDF
+> libraries and connectivity as well as for reasoning that requires
+> tabled Prolog. Updates deal with modified bnode syntax in the RDF
+> libraries, changes to command line options, improved documentation
+> based on compatibility between GitHub markdown and PlDoc.
+
+This documentation is intended to be read via SWI-Prolog's PlDoc
+documentation system.
 
 ## Installation
 
-See INSTALL.md
+See [INSTALL.md](INSTALL.md)
 
 You can bypass installation and use the 'thea' script directly. See
 below.
@@ -17,7 +26,7 @@ below.
 
 The module owl2_io.pl provides a means of loading and saving OWL2
 axioms in a prolog model using predicates such as load_axioms/3 and
-save_axioms/3. For example =|load_axioms('pizza.owl').|=
+save_axioms/3. For example `load_axioms('pizza.owl')`
 
 The model is documented in owl2_model.pl, and is based on Structural
 Specification and Functional-Style Syntax for OWL2
@@ -52,7 +61,7 @@ owl2_java_owlapi.pl).
 
 ## Command Line Usage
 
-The script "thea" in the bin directory should work from anywhere, with
+The script `thea` in the `bin` directory should work from anywhere, with
 no installation of thea modules required.
 
 Type
@@ -98,23 +107,24 @@ See also the apps/ directory for example applications.
 ## Reasoning support
 
 The DLP subset of OWL2-DL can be translated to logic programs using a
-transformation defined by Grosof. See owl2_to_prolog_dlp.pl
+transformation defined by Grosof. See `owl2_to_prolog_dlp.pl`
 
-The resulting programs can be used with Prologs such as Yap and
-XSB. There are also hooks for answer set programming and disjunctive
-datalog systems such as DLV.
+The resulting programs can be used with tabled Prolog systems such as
+YAP, XSB or SWI-Prolog. There are also hooks for answer set programming
+and disjunctive datalog systems such as DLV.
 
-There is also a very partial TBox reasoner in owl2_reasoner.pl, and an
-ad-hoc reasoner in owl2_basic_reasoner.pl that can be used with a
-non-tabled prolog such as SWI; however, this gives incomplete results.
+There is also a very partial TBox reasoner in `owl2_reasoner.pl`, and an
+ad-hoc reasoner in `owl2_basic_reasoner.pl` that can be used with
+non-tabled Prolog implementation; however, this gives incomplete
+results.
 
 The DIG interface from Thea1 has yet to be converted. However, as we
 now have OWLLink support, and DIG is being retired in favor of OWLLink.
 
 You can also use java reasoners via the OWLAPI bridge. See
-owl2_owlapi_java.pl
+`owl2_owlapi_java.pl`
 
-For more information see Reasoning_using_Thea.txt
+For more information see [Reasoning_using_Thea.md](Reasoning_using_Thea.md)
 
 ## Relationship to SWI-Prolog SemWeb Library
 
@@ -142,12 +152,12 @@ care must be taken when doing this.
 
 ## Prolog Compatibility
 
-The goal is to keep the core ISO compliant and usable across prolog
+The goal is to keep the core ISO compliant and usable across Prolog
 systems but this is difficult due to the different implementations of
 modules in different Prolog engines. We develop for SWI-Prolog and are
 aiming for full support for Yap in the near future.
 
-See the iso/ directory for a dynamically generated version of some
+See the `iso/` directory for a dynamically generated version of some
 Thea modules, stripped of module declarations. This is usable in
 no-module systems like GNU Prolog and systems with incompatible module
 syntax such as XSB. Only a subset of Thea functionality will be
@@ -181,3 +191,4 @@ Some of the code was developed by CJM
 Contributions from:
 
 * Martin Güther
+* Jan Wielemaker

--- a/Reasoning_using_Thea.md
+++ b/Reasoning_using_Thea.md
@@ -1,4 +1,3 @@
-
 # Using Thea for Reasoning
 
 An ontology specified in OWL is amenable to reasoning. Some of the
@@ -6,21 +5,20 @@ uses of reasoning are:
 
  * To check for inconsistencies in an ontology
  * To classify the ontology (i.e. find all implied subClassOf/2 relationships)
- * To classify instances using the ontology (i.e. find all implied classAssertuon/2 relationships)
+ * To classify instances using the ontology (i.e. find all implied classAssertion/2 relationships)
 
 Thea2 offers a number of different options for reasoning. These can be
 broken down into the following categories:
 
  * Use of an external reasoning engine
- * Direct use of prolog engine
+ * Direct use of Prolog engine
 
 There are 2 main ways of accessing external reasoning engines - via
 the Java OWLAPI (which requires the JPL bridge) or across a network
 via OWLLink. A third way is via an external Logic Programming engine.
 
 The alternative to using an external reasoning engine is to reason
-using Prolog. At this time, this means SWI-Prolog, and
-backward-chaining based reasoning.
+using Prolog.  See [below](#reasoning-using-prolog).
 
 ## Use of a Java reasoning engine via JPL
 
@@ -83,28 +81,28 @@ mammal(X) :- cat(X).
 cat(mr_whiskers).
 ```
 
-See owl2_to_prolog_dlp.pl module documentation for details.
+See `owl2_to_prolog_dlp.pl` module documentation for details.
 
 This is useful for reasoning over ABoxes (individual), but not TBoxes.
 
-A tabled prolog is recommended here, to avoid non-termination.
+A tabled Prolog is recommended here, to avoid non-termination.
 
 The second approach can actually be further subdivided depending on
 whether backward chaining or a tabled prolog is used.
 
-If you are using a tabled prolog (e.g. Yap or XSB), you can use the
-module owl2_reasoner_rules.pl which defines rules such as this:
+If you are using a tabled prolog, you can use the module
+`owl2_reasoning_rules.pl` which defines rules such as this:
 
 ```
 subClassOf(X,Y) :- subClassOf(X,Z),subClassOf(Z,Y).
 ```
 
-If you are using SWI-Prolog, you can use owl2_basic_reasoner.pl which
-has backwards chaining rules. Caveat emptor: this module is
-experimental, liable to change and could be non-terminating. See the
+The module `owl2_basic_reasoner.pl` provides backwards chaining rules
+for Prolog implementations without tabling. Caveat emptor: this module
+is experimental, liable to change and could be non-terminating. See the
 module docs for details.
 
-Another implementation is provided in owl2_rl_rules.pl. The module
+Another implementation is provided in `owl2_rl_rules.pl`. The module
 implements OWL RL Rules with simple forward and backward chaining engines
 See more in module documentation
 
@@ -112,7 +110,7 @@ See more in module documentation
 
 Currently each of the modules described above provides their own
 particular predicates. This isn't ideal for the application
-programmer. 
+programmer.
 
 We have a prototype of a common API for all reasoning engines, see
 owl2_reasoner.pl (not yet functional).
@@ -141,7 +139,7 @@ forall(reasoner_ask(Reasoner,subClassOf(X,Y)),
 
 [VV] Querying an external reasoner via OWLLink with non-ground queries is not trivial.
 OWLLink does not support variables in its Ask specification. One should write the logic
-on how the system should handle free variables: 
+on how the system should handle free variables:
 E.g. write something like the following:
 
 ```
@@ -150,7 +148,6 @@ E.g. write something like the following:
 		owllink(R, getAllClasses(KB),classSet(CL),[]),
 		member(X,CL),
 		owllink(R, isClassSubsumedBy(KB,X,Y),response(true),[]).
-		
 ```
 
 
@@ -164,7 +161,7 @@ E.g. write something like the following:
   * owl2_rl_rules.pl
   * owl2_basic_reasoner.pl
 
---+++ Reasoner Cookbook
+### Reasoner Cookbook
 
   * TODO
 

--- a/owl2_export_rdf.pl
+++ b/owl2_export_rdf.pl
@@ -18,15 +18,23 @@
            owl_generate_rdf/4, % Ontology,FileName, RDF_Load_Mode (complete/not), Opts
            owl_synchronize_to_rdf/0,
            owl_synchronize_to_rdf/1,
-           owl_rdf2n3/0
+           owl_rdf2n3/0,
+                                        % JW: needed in owl2_util.pl
+           owl2_export_list/2,          % +List, -Node
+           owl_rdf_assert/3,            % +S, +P, +O
+           as2rdf_bnode/2               % +X, -Node
 	  ]).
 
 :- use_module(owl2_model).
 :- use_module(owl2_from_rdf).
 :- use_module(swrl_rdf_hooks).
-:- use_module(library('semweb/rdf_db')).
+:- use_module(library(semweb/rdf_db)).
+:- use_module(library(semweb/turtle)).
 
 :- multifile owl2_io:save_axioms_hook/3.
+
+:- dynamic
+        blanknode_gen/2.
 
 owl2_io:save_axioms_hook(File,ttl,Opts) :-
         ensure_loaded(library('semweb/rdf_turtle_write')),
@@ -698,7 +706,7 @@ owl_rdf_assert(S,P,O) :-
 /*
 as2rdf_bnode(+X,-Node).
         It generates a bnode Node for construct X in case it does not
-	exist already as a blanknode/3 clause.
+	exist already as a blanknode/2 clause.
 */
 as2rdf_bnode(X,Node) :-
 	blanknode_gen(Node,X),

--- a/owl2_from_rdf_utils.pl
+++ b/owl2_from_rdf_utils.pl
@@ -16,7 +16,10 @@ owl_clear_as :-
 predspec_head(Pred/A,Head) :- functor(Head,Pred,A).
 
 u_assert(Term) :-
-	call(Term), !; assert(Term).
+        (   call(Term)
+        ->  true
+        ;   assert(Term)
+        ).
 
 
 convert(T,V,typed_value(T,V)).
@@ -91,7 +94,7 @@ test_use_owl(X1,Y1,Z1,named) :-
 	expand_ns(Y1,Y),
 	expand_ns(Z1,Z),
 	owl(X,Y,Z, not_used),
-	not(sub_string(X,0,2,_,'_:')).
+	\+ sub_string(X,0,2,_,'_:').
 
 
 %%       use_owl(+Triples:list)
@@ -156,7 +159,7 @@ use_owl(X1,Y1,Z1,named,Term) :-
 	expand_ns(Y1,Y),
 	expand_ns(Z1,Z),
 	owl(X,Y,Z, not_used),
-	not(sub_string(X,0,2,_,'_:')),
+	\+ sub_string(X,0,2,_,'_:'),
 	retract(owl(X,Y,Z, not_used)),
 	assert(owl(X,Y,Z,used(Term))).
 
@@ -167,10 +170,10 @@ use_owl(X1,Y1,Z1,named,Term) :-
 %       substituting the full expansion for ns from the ns/2 facts
 expand_ns(NS_URL, Full_URL) :-
 	nonvar(NS_URL),
-	not(NS_URL = literal(_)),
+	NS_URL \= literal(_),
 	uri_split(NS_URL,Short_NS,Term, ':'),
 	rdf_db:ns(Short_NS,Long_NS),!,
-	concat_atom([Long_NS,Term],Full_URL).
+        atomic_list_concat([Long_NS,Term],Full_URL).
 
 expand_ns(URL, URL).
 
@@ -188,7 +191,7 @@ expand_ns(URL, URL).
 collapse_ns(FullURL, NSURL,Char,Options) :-
 	nonvar(FullURL),
         FullURL \= '$VAR'(_),
-	not(FullURL = literal(_)),
+	FullURL \= literal(_),
 	uri_split(FullURL,LongNS, Term, '#'),
 	concat(LongNS,'#',LongNS1),
 	rdf_db:ns(ShortNS,LongNS1),
@@ -260,7 +263,7 @@ owl_collect_linked_nodes(_,_,List, List) :- !.
 
 owl_get_bnode(Node,Description) :-
 	sub_string(Node,0,2,_,'_:'),!,
-	not( blanknode(Node,_,_)),
+	\+ blanknode(Node,_,_),
 	assert(blanknode(Node,Description, used)).
 
 owl_get_bnode(_,_).

--- a/owl2_from_rdf_utils.pl
+++ b/owl2_from_rdf_utils.pl
@@ -187,18 +187,20 @@ expand_ns(URL, URL).
 
 collapse_ns(FullURL, NSURL,Char,Options) :-
 	nonvar(FullURL),
+        FullURL \= '$VAR'(_),
 	not(FullURL = literal(_)),
 	uri_split(FullURL,LongNS, Term, '#'),
 	concat(LongNS,'#',LongNS1),
 	rdf_db:ns(ShortNS,LongNS1),
-	(   member(no_base(ShortNS),Options), ! , NSURL = Term
-	;
-	concat_atom([ShortNS,Char,Term],NSURL)
+	(   member(no_base(ShortNS),Options)
+        ->  NSURL = Term
+	;   atomic_list_concat([ShortNS,Char,Term],NSURL)
 	),!.
 % CJM
 collapse_ns(FullURL, NSURL,_Char,Options) :-
 	nonvar(FullURL),
-	not(FullURL = literal(_)),
+        FullURL \= '$VAR'(_),
+	FullURL \= literal(_),
 	uri_split(FullURL,LongNS, Term, '#'),
 	member(no_base(LongNS),Options),
         !,

--- a/owl2_manchester_parser.pl
+++ b/owl2_manchester_parser.pl
@@ -208,9 +208,20 @@ expand_curie(Name,_O-NSL,IRI) :-
         memberchk(''-Prefix, NSL),
         !,
         atom_concat(Prefix,Name,IRI).
-expand_curie(inverseOf(X0), O, inverseOf(X)) :-
-        !,
+expand_curie(inverseOf(X0), O, inverseOf(X)) :- !,
         expand_curie(X0, O, X).
+expand_curie(oneOf(L0), O, oneOf(L)) :- !,
+        maplist(expand_curie_o(O), L0, L).
+expand_curie(exactCardinality(C, X0), O, exactCardinality(C, X)) :- !,
+        expand_curie(X0, O, X).
+expand_curie(intersectionOf(L0), O, intersectionOf(L)) :- !,
+        maplist(expand_curie_o(O), L0, L).
+expand_curie(allValuesFrom(P0, CE0), O, allValuesFrom(P,CE)) :-
+        expand_curie(P0, O, P),
+        expand_curie(CE0, O, CE).
+expand_curie(List0, O, List) :-
+        is_list(List0), !,
+        maplist(expand_curie_o(O), List0, List).
 expand_curie(X,_,X).
 
 predefined_prefix(rdfs, 'http://www.w3.org/2000/01/rdf-schema#').
@@ -806,7 +817,7 @@ nni(N) --> nonNegativeInteger(N).
 
 % atomic ::= classIRI | '{' individual { ',' individual } '}' | '(' description ')'
 atomic(X) --> classIRI(X).
-atomic(L) --> ['{'], !, oneOrMore(',',individual,L),['}'].
+atomic(oneOf(L)) --> ['{'], !, oneOrMore(',',individual,L),['}'].
 atomic(X) --> ['('], !, description(X), [')'].
 
 % <NT>AnnotatedList ::= [annotations] <NT> { , [annotations] <NT> }

--- a/owl2_manchester_parser.pl
+++ b/owl2_manchester_parser.pl
@@ -803,9 +803,8 @@ conjunction(intersectionOf([Genus|DL])) --> classIRI(Genus), [that], !, oneOrMor
 conjunction(D) -->
         primary(P),
         (   [and]
-        ->  primary(D1),
-            zeroOrMore(and, primary, DL),
-            { D = intersectionOf([P,D1|DL]) }
+        ->  oneOrMore(and, primary, DL),
+            { D = intersectionOf([P|DL]) }
         ;   { D = P }
         ).
 

--- a/owl2_manchester_parser.pl
+++ b/owl2_manchester_parser.pl
@@ -93,6 +93,10 @@ process_property(characteristics=CL,IRI,Type,O,Axioms) :-
 	findall(Axiom,(member(C,CL),
 		       process_characteristic(C,IRI,Type,O,Axiom)),
 		Axioms).
+process_property(P=VL0,IRI,Type,O,[Axiom]) :-
+        list_slot_axiom(P, Type, O, IRI, VL, Axiom),
+        !,
+        maplist(expand_value(O), VL0, VL).
 process_property(P=VL,IRI,Type,O,Axioms) :-
 	!,
 	findall(Axiom,(member(V,VL),
@@ -120,10 +124,31 @@ process_slot_value(S,V0,IRI,T,O,Ax) :-
             Ax =.. [S,IRI,V]
         ).
 
+%!      list_slot_axiom(+Attribute, +IRIType, +O, +IRI, +Value, -Axiom)
+
+list_slot_axiom(disjointWith, objectProperty, _,
+                IRI, V, disjointProperties([IRI|V])).
+list_slot_axiom(equivalentTo, objectProperty, _,
+           IRI, V, equivalentProperties([IRI|V])).
+list_slot_axiom(equivalentTo, dataProperty, _,
+           IRI, V, equivalentProperties([IRI|V])).
+list_slot_axiom(equivalentTo, class, _,
+           IRI, V, equivalentClasses([IRI|V])).
+list_slot_axiom(disjointWith, objectProperty, _,
+           IRI, V, disjointProperties([IRI|V])).
+list_slot_axiom(disjointWith, dataProperty, _,
+           IRI, V, disjointProperties([IRI|V])).
+list_slot_axiom(disjointWith, class, _,
+           IRI, V, disjointClasses([IRI|V])).
+list_slot_axiom(sameAs, namedIndividual, _,
+           IRI, V, sameIndividual([IRI|V])).
+list_slot_axiom(differentFrom, namedIndividual, _,
+           IRI, V, differentIndividuals([IRI|V])).
+list_slot_axiom(disjointUnionOf, class, _,
+           IRI, V, disjointUnion(IRI, V)).
+
 %!      slot_axiom(+Attribute, +IRIType, +O, +IRI, +Value, -Axiom)
 
-slot_axiom(disjointWith, objectProperty, _,
-           IRI, V, disjointProperties([IRI,V])).
 slot_axiom(inverseOf, _, _,
            IRI, V, inverseProperties(IRI,V)).
 slot_axiom(domain, _, _,
@@ -138,22 +163,6 @@ slot_axiom(facts, _, O,
 slot_axiom(facts, _, O,
            IRI, not(P-V0), negativePropertyAssertion(P,IRI,V)) :-
         expand_curie(V0,O,V).
-slot_axiom(equivalentTo, objectProperty, _,
-           IRI, V, equivalentProperties([IRI,V])).
-slot_axiom(equivalentTo, dataProperty, _,
-           IRI, V, equivalentProperties([IRI,V])).
-slot_axiom(equivalentTo, class, _,
-           IRI, V, equivalentClasses([IRI,V])).
-slot_axiom(disjointWith, objectProperty, _,
-           IRI, V, disjointProperties([IRI,V])).
-slot_axiom(disjointWith, dataProperty, _,
-           IRI, V, disjointProperties([IRI,V])).
-slot_axiom(disjointWith, class, _,
-           IRI, V, disjointClasses([IRI,V])).
-slot_axiom(sameAs, namedIndividual, _,
-           IRI, V, sameIndividual([IRI,V])).
-slot_axiom(differentFrom, namedIndividual, _,
-           IRI, V, differentIndividuals([IRI,V])).
 
 %!      slot_axiom(+Attribute, +IRIType) is semidet.
 %
@@ -163,6 +172,12 @@ slot_axiom(subClassOf,    class).
 slot_axiom(subPropertyOf, objectProperty).
 slot_axiom(subPropertyOf, dataProperty).
 slot_axiom(subPropertyOf, annotationProperty).
+
+%!      expand_value(+O, +V0, -V)
+
+expand_value(O, V0, V) :-
+        value_annotations(V0, V1, _),
+        expand_curie(V1, O, V).
 
 %!      value_annotations(+Value0, -Value, -Annotations) is det.
 %

--- a/owl2_manchester_parser.pl
+++ b/owl2_manchester_parser.pl
@@ -547,10 +547,10 @@ classIRI(X) --> iri(X).
 
 % Datatype ::= datatypeIRI | 'integer' | 'decimal' | 'float' | 'string'
 datatype(X) --> datatypeIRI(X).
-datatype(integer) --> [integer].
-datatype(decimal) --> [decimal].
-datatype(float) --> [float].
-datatype(string) --> [string].
+datatype('http://www.w3.org/2001/XMLSchema#integer') --> [integer].
+datatype('http://www.w3.org/2001/XMLSchema#decimal') --> [decimal].
+datatype('http://www.w3.org/2001/XMLSchema#float') --> [float].
+datatype('http://www.w3.org/2001/XMLSchema#string') --> [string].
 
 % datatypeIRI ::= IRI
 datatypeIRI(X) --> iri(X).

--- a/owl2_manchester_parser.pl
+++ b/owl2_manchester_parser.pl
@@ -102,27 +102,29 @@ process_annotation(IRI,_Type,O,
 process_characteristic(C,IRI,_Type,_,Unary) :-
 	slot_predicate(C,P),
 	Unary =.. [P,IRI].
-	%writeln(u=Unary),
-	%assert_axiom(Unary).
 
-%process_slot_value(S,V,IRI,T,O,Ax) :-
-%	process_slot_value(S,V,IRI,T,O,Ax).
-	%writeln(ax=Ax),
-	%assert_axiom(Ax).
+process_slot_value(S,V0,IRI,T,O,Ax) :-
+        annotations(V0, V1, _Annotations),
+	expand_curie(V1,O,V),
+        (   slot_axiom(S, T, IRI, V, Ax)
+        ->  true
+        ;   debug(man(axioms), 'guessing for: ~p', [S-T]),
+            Ax =.. [S,IRI,V]
+        ).
 
-process_slot_value(disjointWith,V,IRI,objectProperty,O,Ax) :-
-	!,
-	expand_curie(V,O,VX),
-	Ax = disjointProperties([IRI,VX]).
-process_slot_value(inverseOf,V,IRI,_,O,Ax) :-
-	!,
-	expand_curie(V,O,VX),
-	Ax = inverseProperties(IRI,VX).
-process_slot_value(S,V,IRI,T,O,Ax) :-
-	%writeln(eh(S,T)),
-        format(user_error,'guessing for: ~w~n',[S-T]),
-	expand_curie(V,O,VX),
-	Ax =.. [S,IRI,VX].
+%!      slot_axiom(+Attribute, +IRIType, +IRI, +Value, -Axiom)
+
+slot_axiom(disjointWith, objectProperty, IRI, V, disjointProperties([IRI,V])).
+slot_axiom(inverseOf, _, IRI, V, inverseProperties(IRI,V)).
+slot_axiom(domain, _, IRI, V, propertyDomain(IRI,V)).
+
+%!      annotations(+Value0, -Value, -Annotations) is det.
+%
+%       Split the annotations from the value
+
+annotations(Value, Value, []).
+
+%!      expand_curie(+ASTValue, +Ontology, -RDFValue)
 
 expand_curie(IRI, _, IRI) :-
         atom(IRI),

--- a/owl2_manchester_parser.pl
+++ b/owl2_manchester_parser.pl
@@ -114,6 +114,8 @@ process_slot_value(S,V0,IRI,T,O,Ax) :-
 	expand_curie(V1,O,V),
         (   slot_axiom(S, T, O, IRI, V, Ax)
         ->  true
+        ;   slot_axiom(S, T)
+        ->  Ax =.. [S,IRI,V]
         ;   debug(man(axioms), 'guessing for: ~p', [S-T]),
             Ax =.. [S,IRI,V]
         ).
@@ -136,6 +138,31 @@ slot_axiom(facts, _, O,
 slot_axiom(facts, _, O,
            IRI, not(P-V0), negativePropertyAssertion(P,IRI,V)) :-
         expand_curie(V0,O,V).
+slot_axiom(equivalentTo, objectProperty, _,
+           IRI, V, equivalentProperties([IRI,V])).
+slot_axiom(equivalentTo, dataProperty, _,
+           IRI, V, equivalentProperties([IRI,V])).
+slot_axiom(equivalentTo, class, _,
+           IRI, V, equivalentClasses([IRI,V])).
+slot_axiom(disjointWith, objectProperty, _,
+           IRI, V, disjointProperties([IRI,V])).
+slot_axiom(disjointWith, dataProperty, _,
+           IRI, V, disjointProperties([IRI,V])).
+slot_axiom(disjointWith, class, _,
+           IRI, V, disjointClasses([IRI,V])).
+slot_axiom(sameAs, namedIndividual, _,
+           IRI, V, sameIndividual([IRI,V])).
+slot_axiom(differentFrom, namedIndividual, _,
+           IRI, V, differentIndividuals([IRI,V])).
+
+%!      slot_axiom(+Attribute, +IRIType) is semidet.
+%
+%       Indicates that the generic translation is correct.
+
+slot_axiom(subClassOf,    class).
+slot_axiom(subPropertyOf, objectProperty).
+slot_axiom(subPropertyOf, dataProperty).
+slot_axiom(subPropertyOf, annotationProperty).
 
 %!      value_annotations(+Value0, -Value, -Annotations) is det.
 %
@@ -170,15 +197,15 @@ expand_curie(X,_,X).
 expand_curie_o(O,AST,RDF) :-
         expand_curie(AST,O,RDF).
 
-slot_predicate(S,P) :-
-	sub_atom(S,0,1,_,C1),
-	C1 @>= 'A',
-	C1 @=< 'Z',
-	!,
-	downcase_atom(C1,C2),
-	sub_atom(S,1,_,0,S2),
-	atom_concat(C2,S2,P).
-slot_predicate(S,S).
+%!      slot_predicate(+Characteristic, -AxiomName)
+
+slot_predicate('Functional',        functionalProperty).
+slot_predicate('InverseFunctional', inverseFunctionalProperty).
+slot_predicate('Reflexive',         reflexiveProperty).
+slot_predicate('Irreflexive',       irreflexiveProperty).
+slot_predicate('Symmetric',         symmetricProperty).
+slot_predicate('Asymmetric',        asymmetricProperty).
+slot_predicate('Transitive',        transitiveProperty).
 
 % ----------------------------------------
 % Tokenization

--- a/owl2_model.pl
+++ b/owl2_model.pl
@@ -1216,12 +1216,9 @@ retract_axiom(Axiom,Ontology) :-
 
 
 retract_all_axioms :-
-        findall(A,axiom(A),Axioms),
-        maplist(retract,Axioms),
-        findall(ontologyAxiom(O,A),ontologyAxiom(O,A),OAxioms),
-        maplist(retract,OAxioms),
-	!.
-
+	forall(axiom(A), retract(A)),
+        forall(ontologyAxiom(O,A),		% JW: why not retractall/1?
+	       retract(ontologyAxiom(O,A))).
 
 owl2_model_init :-
 	assert(annotationProperty('http://www.w3.org/2000/01/rdf-schema#label')),

--- a/owl2_model.pl
+++ b/owl2_model.pl
@@ -118,8 +118,10 @@
            axiom_type/2,
 
            valid_axiom/1,
-           is_valid_axiom/1
+           is_valid_axiom/1,
 
+	   literal/1,			% JW: Added as needed in swrl
+	   builtin_class/1
 	  ]).
 %:- require([ is_list/1
 %	   , current_prolog_flag/2

--- a/owl2_model.pl
+++ b/owl2_model.pl
@@ -748,9 +748,7 @@ subsumed_by(L,set(T)):-
         forall(member(I,L),
                subsumed_by(I,T)).
 subsumed_by(I,T):-
-        !,
-	G=..[T,I],
-	G.
+	call(T,I).
 
 
 %% iri(?IRI)

--- a/owl2_model.pl
+++ b/owl2_model.pl
@@ -1221,8 +1221,18 @@ retract_all_axioms :-
 	       retract(ontologyAxiom(O,A))).
 
 owl2_model_init :-
-	assert(annotationProperty('http://www.w3.org/2000/01/rdf-schema#label')),
-	assert(annotationProperty('http://www.w3.org/2000/01/rdf-schema#comment')).
+	u_assert(annotationProperty('http://www.w3.org/2000/01/rdf-schema#label')),
+	u_assert(annotationProperty('http://www.w3.org/2000/01/rdf-schema#comment')),
+	u_assert(datatype('http://www.w3.org/2001/XMLSchema#integer')),
+	u_assert(datatype('http://www.w3.org/2001/XMLSchema#decimal')),
+	u_assert(datatype('http://www.w3.org/2001/XMLSchema#float')),
+	u_assert(datatype('http://www.w3.org/2001/XMLSchema#string')).
+
+u_assert(Clause) :-
+	(   call(Clause)
+	->  true
+	;   assert(Clause)
+	).
 
 consult_axioms(File) :-
         consult(File).

--- a/owl2_to_prolog_dlp.pl
+++ b/owl2_to_prolog_dlp.pl
@@ -203,27 +203,22 @@ owl_write_prolog_code( ( ( H1; H2) :- B), Options) :- !,
         ;   true).
 
 owl_write_prolog_code( (H :- B), Options) :-!,
-	(   H = false , !
-	;
-	B = false , !
-	;
-	H = [], !
-	;
-	H = [_|_] , !,
-	    maplist(map_head_conjunction(B),H,R),
+	(   H == false
+        ->  true
+        ;   B == false
+        ->  true
+        ;   H == []
+        ->  true
+        ;   H = [_|_]
+        ->  maplist(map_head_conjunction(B),H,R),
 	    owl_write_prolog_code(R,Options) % rewrite rule (a,b) :- c ==> a :- c and b:-c
-
-	;
-	H = (H1 :- H2) , !,
-	    owl_write_prolog_code(:-(H1,(H2,B)),Options) % rewrite rule a :- b) :- c ==> a :- b,c
-	;
-	H = (H1 ; H2) , !,
-	    owl_write_prolog_head_disjunction(H,Options)
-	;
-	B = none, !, % It is a fact (no body).
-	    owl_write_prolog_code(H,Options), write('.'), nl
-	;
-	owl_write_prolog_code(H,Options), write(':-'), % normal rule H:-B.
+	;   H = (H1 :- H2)
+        ->  owl_write_prolog_code((H1:-(H2,B)),Options) % rewrite rule a :- b) :- c ==> a :- b,c
+	;   H = (_ ; _)
+        ->  owl_write_prolog_head_disjunction(H,Options)
+	;   B = none % It is a fact (no body).
+        ->  owl_write_prolog_code(H,Options), write('.'), nl
+	;   owl_write_prolog_code(H,Options), write(':-'), % normal rule H:-B.
 	    nl, write('     '),
 	    owl_write_prolog_code(B,Options),
 	    write('.'), nl

--- a/owl2_util.pl
+++ b/owl2_util.pl
@@ -44,18 +44,20 @@
 :- use_module(owl2_xml).
 :- use_module(owl2_catalog).
 :- use_module(owl2_reasoner).
+:- use_module(owl2_export_rdf).
 
 
-:-use_module(library('http/http_open')).
-:-use_module(library('http/http_client')).
-:-use_module(library('http/thread_httpd.pl')).
-:-use_module(library(sgml)).
+:- use_module(library('http/http_open')).
+:- use_module(library('http/http_client')).
+:- use_module(library('http/thread_httpd.pl')).
+:- use_module(library(sgml)).
+:- use_module(library(semweb/rdf11)).
 
 
 % @Deprecated
 % use owl2_io
 owl_parse_pro(F):-
-        owl2_model:consult(F).
+        consult(owl2_model:F).
 
 
 % @Deprecated
@@ -219,7 +221,7 @@ replace_labels_with_IRIs:-
         translate_IRIs(get_IRI_from_label).
 
 remove_ns(IRI,X) :-
-        concat_atom([_,X],'#',IRI),
+        atomic_list_concat([_,X],'#',IRI),
         !.
 remove_ns(X,X).
 
@@ -232,12 +234,12 @@ replace_ns_prefix(_,_,X,X).
 
 contract_ns(URI,ID) :-
         atom(URI),
-        rdf_db:rdf_global_id(NS:Local,URI),
+        rdf_global_id(NS:Local,URI),
         NS \= rdf,
         NS \= rdfs,
         NS \= owl,
         !,
-        concat_atom([NS,Local],':',ID).
+        atomic_list_concat([NS,Local],':',ID).
 contract_ns(X,X).
 
 
@@ -266,7 +268,7 @@ get_IRI_from_label(X,X).
 use_property_as_IRI(Prop,IRI,NewIRI) :-
         anyPropertyAssertion(Prop,IRI,Literal),
 	Literal=literal(type(_,Val)),
-	concat_atom([NS,Local],':',Val),
+	atomic_list_concat([NS,Local],':',Val),
 	rdf_global_id(NS:Local,NewIRI),
         !.
 use_property_as_IRI(X,X).
@@ -395,9 +397,9 @@ collect_orphan_axioms(Ont) :-
         forall((axiom(A),\+ontologyAxiom(_,A)),
                assert_axiom(A,Ont)).
 
-               
-               
-        
+
+
+
 
 %% extract_axiom_template(+Ax,?Template)
 % replaces atoms with variables
@@ -469,7 +471,9 @@ owlpredargs :-
         format('~q.~n',[owlpredicate_arguments(TP,L)]),
         fail.
 
-get_class(Q,C) :- annotationLabel_value(C,Q),!.
+% JW: annotationLabel_value/2 is undefined. As this is not called anyway,
+% this seems safe.
+% get_class(Q,C) :- annotationLabel_value(C,Q),!.
 get_class(C,C).
 
 show_superclasses(R,Q) :-
@@ -554,7 +558,7 @@ isalpha(X) :- X @>= 'A',X @=< 'Z'.
 isalpha(X) :- X @>= '0',X @=< '9'.
 
 
-               
+
 
 stats(File) :- owl_statistics(all,XML), open(File,write,S), xml_write(S,XML,[header(true)]),close(S).
 

--- a/owl2_xml.pl
+++ b/owl2_xml.pl
@@ -184,10 +184,16 @@ xml_annotation(element(_:'Annotation',Atts,Elts),annotation(P,V)) :-
         Elts=[element(_:'Constant',_,[V])].
 
 atts_iri(Atts,TIRI) :-
-  	(   TIRI = i(IRI) ; TIRI = c(IRI) ; TIRI = op(IRI); TIRI = dp(IRI) ; var(IRI)),!,
+        tiri_iri(TIRI, IRI),
 	iri_att(A),
         member(A=IRI,Atts).
 
+tiri_iri(i(IRI), IRI) :- !.
+tiri_iri(c(IRI), IRI) :- !.
+tiri_iri(op(IRI), IRI) :- !.
+tiri_iri(dp(IRI), IRI) :- !.
+tiri_iri(IRI, IRI) :- % JW: not entirely sure here.  The original code
+        var(IRI).     % is definitely wrong though.
 
 iri_att('URI').  % TODO clarify. P4 uses this
 iri_att('abbreviatedIRI').  % VV add 15/10 for OWLLink support

--- a/owl2_xml.pl
+++ b/owl2_xml.pl
@@ -45,7 +45,7 @@ owl_parse_xml(File,_) :-
         throw(no_parse(File)).
 
 xsb_owl_parse_xml(File,_Opts) :-
-        load_structure(file(File),[XML],[dialect(xmlns),space(remove)],_Warn),
+        load_structure(file(File),[XML],[dialect(xmlns),space(remove)]),
         xml_ontology(XML,Ont,Axioms),
         assert_axiom(Ont),
         forall(member(Axiom,Axioms),

--- a/swrl.pl
+++ b/swrl.pl
@@ -71,8 +71,8 @@ swrlAtom(A):-
         ;   A=differentFrom(X,Y)
         ->  i_object(X),i_object(Y)
         ;   A=builtin(X,L)
-        ->  builtin(X),list_of_d_object(L)
-        ;   A=..[F,X]
+        ->  builtin_class(X),list_of_d_object(L) % JW: was builtin/1.
+        ;   A=..[F,X]                   % builtin_class/1 is in owl_model.pl
         ->  class(F),
             i_object(X)
         ;   A=..[F,X,Y]
@@ -114,7 +114,7 @@ normalize_swrl_atom(A, description(Class,Ob) ) :-
 %        A=..[P,X,Y],
 %        !.
 normalize_swrl_atom(A, A).
-                   
+
 
 %% swrl_to_owl_axioms(+SWRLRule,?OWLAxioms) is semidet
 % true if SWRLRule can be translated into OWLAxiom.
@@ -193,7 +193,7 @@ swrl_to_owl(AL,C,subClassOf(Sub,D)) :- % non-normalized form of above rule
         C=..[Sub,v(X)],
         subgoals_to_intersection(AL,X,[D]),
         !.
-swrl_to_owl(AL,C,subClassOf(Sub,D)) :- 
+swrl_to_owl(AL,C,subClassOf(Sub,D)) :-
         C=..[Sub,v(X)],
         subgoals_to_description(AL,X,D),
         !.
@@ -215,7 +215,7 @@ swrl_to_owl([A],description(R,X),propertyRange(P,R)) :-
 % I believe this is called 'marker properties'
 swrl_to_owl(AL,C,Axiom) :-
         C=..[P,X,Y],            % e.g. hasPet(x,y)
-        select(A1,AL,[A2]),     
+        select(A1,AL,[A2]),
         A1=..[P2,X,Y],          % e.g. owns(x,y)
         A2=description(D,Y),  % e.g. animal(y)
         atom(D),
@@ -274,13 +274,13 @@ subgoal_to_description(description(D,V),V,D).
 %% prolog_clause_to_swrl_rule( +Term, ?SWRLAtom:swrlAtom )
 %
 % Prolog clause terms are clauses of the form
-%== 
+%==
 % hasUncle(X1,X3):- hasParent(X1,X2),hasBrother(X2,X3)
 %==
-% 
+%
 % Are translated to embedded swrl.pl rule terms, using
 % the implies/2 functor.
-% 
+%
 % complex atoms still require wrapping:
 %==
 % description(maxCardinality(1,'style/period'),Z) :-
@@ -363,7 +363,7 @@ prolog_term_to_swrl_atom( A, literal(type('xsd:integer',A)) ) :-
 prolog_term_to_swrl_atom( A, A) :-
         atom(A),
         !.
-        
+
 %% prolog_source_to_swrl_rules(+File,?Rules)
 %
 % TODO: use prolog source in pldoc style to generate annotation axioms
@@ -403,12 +403,12 @@ goal_swrlb(X is A*B,multiply(A,B,X)).
 goal_swrlb(X is A/B,divide(A,B,X)).
 
 % arithmetic TODO
-pred_swrlb(<,lessThan). 
+pred_swrlb(<,lessThan).
 pred_swrlb(=,equal). % TODO: detect type
 pred_swrlb(\=,notEqual). % TODO: detect type
-pred_swrlb(=<,lessThanOrEqual). 
-pred_swrlb(>,greaterThan). 
-pred_swrlb(>=,greaterThanOrEqual). 
+pred_swrlb(=<,lessThanOrEqual).
+pred_swrlb(>,greaterThan).
+pred_swrlb(>=,greaterThanOrEqual).
 
 pred_swrlb(=,stringEqualIgnoreCase). % TODO: detect type
 pred_swrlb(atom_length,stringLength).
@@ -451,7 +451,7 @@ owl2_io:load_axioms_hook(File,pl_swrl_owl,Opts) :-
   ---+ Synopsis
 
   Example SWRL Rule embedded as prolog swrl.pl fact:
-  
+
 ==
 implies([hasParent(v(x),v(y)),hasBrother(v(y),v(z))],[hasUncle(v(x),v(z))]).
 ==
@@ -460,7 +460,7 @@ implies([hasParent(v(x),v(y)),hasBrother(v(y),v(z))],[hasUncle(v(x),v(z))]).
 ---+ Details
 
 This extends the owl2_model.pl collection of allowed axioms (see axiom/1) with the implies/2 axiom.
-    
+
 http://www.w3.org/Submission/SWRL/
 
 This module also intends to allow for easy conversion between a natural prolog style and SWRL axioms.


### PR DESCRIPTION
 - 277dcf8 is a bit of a guess.
 - e693356 is a rather serious rewrite that partially addresses the issue of getting variable sharing correct.  I'll probably do a more serious rewrite at some point such that we can simply assert the Prolog program instead of writing a file and loading that.

With these changes we get

```
$ swipl cookbook/wine.pl
?- demo.
% Parsed "wine.owl" in 0.03 sec; 2,264 triples
'WhitehallLanePrimavera' is a light US dessert wine
true.
```